### PR TITLE
Simplified running tests

### DIFF
--- a/Library.js
+++ b/Library.js
@@ -1,3 +1,0 @@
-test("FirstUnitTest", function () {
-  expect(true).toBeTruthy();
-});

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This template setup a minimal application using [Fable](http://fable.io/), [Elmi
 
 ## How to use ?
 
+### Axxes
+
+>.\fake.cmd run .\build.fsx -t Watch
+
 ### Architecture
 
 - Entry point of your application is `src/App.fs`

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "split": "fable-splitter --watch --config splitter.config.js",
-    "test": "jest --watchAll"
+    "build-test": "fable-splitter --config splitter.config.js",
+    "test": "jest"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/src/App.fs
+++ b/src/App.fs
@@ -5,45 +5,21 @@ open Fable.Helpers.React
 open Fable.Helpers.React.Props
 open Fulma
 open Fulma.FontAwesome
+open App.Types
+open App.State
 
-type Color = // enum
-    | Red
-    | Green
-    | Blue
-    | Yellow
-    | Orange
-    | Violet
-
-type Attempt = Color * Color * Color * Color // Tuple
-
-type Model =
-    {
-        CurrentAttempt : Attempt
-        Attempts : Attempt list // list of Attempt
-    }
-
-type Msg =
-    | ChangeValue of string
-
-let init _ =
-    {
-        CurrentAttempt = Color.Red, Color.Red, Color.Red, Color.Red
-        Attempts =  List.empty
-    }
-
-let private update msg model =
-    model
 
 let private view model dispatch =
-    div (*function*) List.empty (*collection of attributes for div*) List.empty (*collection of childs inside div*)
+    // div (*function*) List.empty (*collection of attributes for div*) List.empty (*collection of childs inside div*)
+    div [] [str "WIP 🙃"]
 
 open Elmish.React
 open Elmish.Debug
 open Elmish.HMR
 
-// Program.mkSimple init update view
-// |> Program.withReactUnoptimized "elmish-app"
-// #if DEBUG
-// |> Program.withDebugger
-// #endif
-// |> Program.run
+Program.mkSimple init update view
+|> Program.withReactUnoptimized "elmish-app"
+#if DEBUG
+|> Program.withDebugger
+#endif
+|> Program.run

--- a/src/MasterMind.fsproj
+++ b/src/MasterMind.fsproj
@@ -3,6 +3,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Types.fs" />
+    <Compile Include="State.fs" />
     <Compile Include="App.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />

--- a/src/State.fs
+++ b/src/State.fs
@@ -1,0 +1,12 @@
+module App.State
+
+open App.Types
+
+let init _ =
+    {
+        CurrentAttempt = Color.Red, Color.Red, Color.Red, Color.Red
+        Attempts =  List.empty
+    }
+
+let update msg model =
+    model

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -1,0 +1,20 @@
+module App.Types
+
+type Color = // enum
+    | Red
+    | Green
+    | Blue
+    | Yellow
+    | Orange
+    | Violet
+
+type Attempt = Color * Color * Color * Color // Tuple
+
+type Model =
+    {
+        CurrentAttempt : Attempt
+        Attempts : Attempt list // list of Attempt
+    }
+
+type Msg =
+    | ChangeValue of string

--- a/test/Library.test.fs
+++ b/test/Library.test.fs
@@ -1,6 +1,7 @@
 ﻿module MasterMind.Test
 open Fable.Import.Jest (*jest = testing framework*)
-open App.View
+open App.Types
+open App.State
 
 test "Init Should Not Be Null" <| fun () ->
     let model = init()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const webpack = require("webpack");
-const fableUtils = require("fable-utils");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -108,5 +107,28 @@ module.exports = {
                 use: ["file-loader"]
             }
         ]
+    }
+},
+{
+    entry: "./test/test.fsproj",
+    module: {
+        rules: [
+            {
+                test: /\.fs(x|proj)?$/,
+                use: {
+                    loader: "fable-loader",
+                    options: {
+                        define: isProduction ? [] : ["DEBUG"]
+                    }
+                }
+            },
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: babelOptions
+                },
+            }]
     }
 };


### PR DESCRIPTION
I talked to Maxime on gitter, our approach was pretty spot on yesterday.
The hard part is how we called everything, this can be simplified.

I did some refactoring to have everything running from the `Watch` target inside the FAKE build.fsx.

Now the only thing you is `.\fake.cmd run .\build.fsx -t Watch` and it will watch the tests and also launch webpack-dev-server.